### PR TITLE
defining "install" before first possible use

### DIFF
--- a/crunchyroll_downloader.py
+++ b/crunchyroll_downloader.py
@@ -8,6 +8,20 @@ import concurrent.futures
 
 ###########
 
+def install(packages):
+    for package in packages:
+        try:
+            check_call([sys_executable, "-m", "pip", "install", "--user", package])
+        except CalledProcessError:
+
+            if os.name == "posix":
+                os.system("sudo apt install python3-pip -y")
+                check_call([sys_executable, "-m", "pip", "install", package])
+            else:
+                print("Error: 'pip' not installed.")
+
+###########
+
 if __name__ == "__main__":
     try:
         import youtube_dl
@@ -205,17 +219,6 @@ class Anime():
             print(f"Finished downloading ", os.path.basename(downloader["filename"]))
 
 ###########
-
-def install(packages):
-    for package in packages:
-        try:
-            check_call([sys_executable, "-m", "pip", "install", "--user", package])
-        except CalledProcessError:
-            if os.name == "posix":
-                os.system("sudo apt install python3-pip -y")
-                check_call([sys_executable, "-m", "pip", "install", package])
-            else:
-                print("Error: 'pip' not installed.")
 
 def save_config():
     global config, w_anime


### PR DESCRIPTION
If you do not have all dependencies the script tries to install them. This however calls the function "install" which is not defined at the time.

The issue:
```
Required modules: 'youtube_dl', 'PyYAML', 'PrettyTable'
Do you want to install them now? (y/N): y
Traceback (most recent call last):
  File "crunchyroll_downloader.py", line 15, in <module>
    from prettytable import PrettyTable
ModuleNotFoundError: No module named 'prettytable'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "crunchyroll_downloader.py", line 19, in <module>
    install(["youtube_dl", "PyYAML", "PrettyTable"])
NameError: name 'install' is not defined
```